### PR TITLE
Updated to latest rustc and removed unnecessary Output type param

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 name = "sound_stream"
 
 [dependencies.rust-portaudio]
-git = "https://github.com/jeremyletang/rust-portaudio"
+#git = "https://github.com/jeremyletang/rust-portaudio"
+path = "../rust-portaudio"
 
 [dependencies.time]
 git = "https://github.com/rust-lang/time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 name = "sound_stream"
 
 [dependencies.rust-portaudio]
-#git = "https://github.com/jeremyletang/rust-portaudio"
-path = "../rust-portaudio"
+git = "https://github.com/jeremyletang/rust-portaudio"
 
 [dependencies.time]
 git = "https://github.com/rust-lang/time"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -19,13 +19,12 @@ const CHANNELS: u16 = 2;
 const SETTINGS: Settings = Settings { sample_hz: SAMPLE_HZ, frames: FRAMES, channels: CHANNELS };
 
 pub type Input = f32;
-pub type Output = f32;
-pub type OutputBuffer = Vec<Output>;
+pub type OutputBuffer = Vec<f32>;
 
 fn main() {
 
     // Construct the stream and handle any errors that may have occurred.
-    let mut stream = match SoundStream::<OutputBuffer, Input, Output>::new(SETTINGS) {
+    let mut stream = match SoundStream::<OutputBuffer, Input>::new(SETTINGS) {
         Ok(stream) => stream,
         Err(err) => panic!("An error occurred while constructing SoundStream: {}", err),
     };

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -20,29 +20,35 @@
 //! - [S, ..16384]
 
 use portaudio::pa::Sample;
+use std::num::FromPrimitive;
 
 /// A trait to be implemented by any Buffer used for audio processing in sound_stream.
 /// This is primarily implemented for fixed-size arrays where len is a power of 2.
-pub trait AudioBuffer<S> where S: Sample {
+pub trait AudioBuffer {
+    type Sample: Sample = f32;
     /// Return a Zeroed AudioBuffer.
-    fn zeroed(len: uint) -> Self;
+    fn zeroed(len: usize) -> Self;
     /// Clone the AudioBuffer as a Vec.
-    fn clone_as_vec(&self) -> Vec<S>;
+    fn clone_as_vec(&self) -> Vec<<Self as AudioBuffer>::Sample>;
 }
 
-impl<S> AudioBuffer<S> for Vec<S> where S: Sample {
-    fn zeroed(len: uint) -> Vec<S> { Vec::from_elem(len, FromPrimitive::from_u64(0).unwrap()) }
+impl<S> AudioBuffer for Vec<S> where S: Sample {
+    type Sample = S;
+    fn zeroed(len: usize) -> Vec<S> { 
+        (0..len).map(|_| FromPrimitive::from_u64(0).unwrap()).collect()
+    }
     fn clone_as_vec(&self) -> Vec<S> { self.clone() }
 }
 
 #[macro_escape]
 macro_rules! impl_audio_buffer(
     ($len:expr) => (
-        impl<S> AudioBuffer<S> for [S, ..$len] where S: Sample {
+        impl<S> AudioBuffer for [S; $len] where S: Sample {
+            type Sample = S;
             #[inline]
-            fn zeroed(_len: uint) -> [S, ..$len] { [FromPrimitive::from_u64(0).unwrap(), ..$len] }
+            fn zeroed(_len: usize) -> [S; $len] { [FromPrimitive::from_u64(0).unwrap(); $len] }
             #[inline]
-            fn clone_as_vec(&self) -> Vec<S> { Vec::from_fn($len, |idx| self[idx]) }
+            fn clone_as_vec(&self) -> Vec<S> { (0us..$len).map(|idx| self[idx]).collect() }
         }
     )
 );

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,10 +5,16 @@
 use portaudio::pa::error::Error as PortAudioError;
 
 /// A type for representing errors in sound_stream.
-#[deriving(Show, Copy, Clone)]
+#[derive(Show, Copy, Clone)]
 pub enum Error {
     /// Errors returned by rust-portaudio.
     PortAudio(PortAudioError),
+}
+
+impl ::std::fmt::Display for Error {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        self.fmt(f)
+    }
 }
 
 impl ::std::error::Error for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 
-#![feature(default_type_params, globs, macro_rules, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 extern crate portaudio;
 extern crate time;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 
 /// Settings required for SoundStream.
-#[deriving(Show, Copy, Clone, PartialEq)]
+#[derive(Show, Copy, Clone, PartialEq)]
 pub struct Settings {
     /// The number of samples per second.
     pub sample_hz: u32,
@@ -33,8 +33,8 @@ impl Settings {
     }
 
     /// Return the length of a SoundBuffer that would use Settings.
-    pub fn buffer_size(&self) -> uint {
-        self.frames as uint * self.channels as uint
+    pub fn buffer_size(&self) -> usize {
+        self.frames as usize * self.channels as usize
     }
 
 }


### PR DESCRIPTION
The Output type parameter is no longer needed as the type can be accessed via the AudioBuffer trait using associated types.