### PR TITLE
Fix for rust-portaudio >=0.4.0

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -164,7 +164,8 @@ impl<'a, I, O> SoundStreamBuilder<'a, I, O>
                                       Some(&output_stream_params),
                                       stream_settings.sample_hz as f64,
                                       stream_settings.frames as u32,
-                                      pa::StreamFlags::ClipOff) {
+                                      pa::StreamFlags::ClipOff,
+                                      None) {
             return Err(Error::PortAudio(err))
         }
 


### PR DESCRIPTION
The stream.open method [has been changed](https://github.com/jeremyletang/rust-portaudio/pull/68) to allow a non blocking call. The last parameter supports a callback. Passing `None` as the last argument is now a blocking call.